### PR TITLE
Fix for loader

### DIFF
--- a/src/display-fibonacci.js
+++ b/src/display-fibonacci.js
@@ -26,7 +26,7 @@ function DisplayFibonacci () {
   }, [ wantedNumber ])
 
   function handleChange (n) {
-    setIsLoading(true)
+    setIsLoading(n !== wantedNumber)
     setNumber(n)
   }
 


### PR DESCRIPTION
If the number that changed was the same as before, e.g. if the user
changed `10` to `010` the loader was shown but never disappeared.